### PR TITLE
Enable automatic keymap loading and restore build script

### DIFF
--- a/EZOverlay/Layout/LayoutRepository.swift
+++ b/EZOverlay/Layout/LayoutRepository.swift
@@ -8,7 +8,9 @@ final class LayoutRepository: ObservableObject {
     private let currentLayerKey = "CurrentLayerID"
     
     init() {
-        loadDefaultLayers()
+        if !loadKeymapJSONIfPresent() {
+            loadDefaultLayers()
+        }
         loadCurrentLayer()
     }
     
@@ -26,6 +28,19 @@ final class LayoutRepository: ObservableObject {
         setCurrentLayer(availableLayers[index])
     }
     
+    private func loadKeymapJSONIfPresent() -> Bool {
+        let searchPaths = ["keymap.json", "../keymap.json"]
+        let fileManager = FileManager.default
+
+        for path in searchPaths {
+            let url = URL(fileURLWithPath: path)
+            if fileManager.fileExists(atPath: url.path) {
+                return loadOryxLayout(from: url)
+            }
+        }
+        return false
+    }
+
     private func loadDefaultLayers() {
         // Default layers for v1 - these would eventually load from PNG assets or JSON
         availableLayers = [

--- a/EZOverlay/Package.swift
+++ b/EZOverlay/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
             exclude: [
                 "Tests", 
                 "Package.swift", 
-                "build.sh", 
                 "test_with_screenshots.sh",
                 "Info.plist"
             ],

--- a/EZOverlay/README.md
+++ b/EZOverlay/README.md
@@ -7,6 +7,7 @@ A macOS application that displays an Ergodox EZ keyboard layout as a translucent
 - **Global Hotkey Toggle**: Press `Cmd+Option+Ctrl+L` to show/hide overlay
 - **Transparent Overlay**: Borderless, transparent window that appears on all Spaces
 - **Auto Layer Switching**: F13-F20 keys automatically switch overlay layers (requires Input Monitoring permission)
+- **Custom Keymap Support**: Automatically loads your `keymap.json` layout if present
 - **Click-through Support**: Configurable click-through behavior
 - **Multi-Space Support**: Overlay appears on all desktop Spaces and over full-screen apps
 - **Customizable Opacity**: Adjust overlay transparency via preferences

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Build the EZOverlay application in release mode
+cd EZOverlay
+swift build --configuration release


### PR DESCRIPTION
## Summary
- load `keymap.json` automatically on startup so the overlay uses your custom layout
- restore a top-level `build.sh` for building the app
- clean up package manifest and docs for custom keymap support

## Testing
- `./test_app.sh` *(fails: no such module 'AppKit')*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6a77978832595f7d824c30521d6